### PR TITLE
chore:  bump go version and tidy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
       - name: Determine download URL for pkger
         id: pkger-download-url
         uses: actions/github-script@v2
@@ -78,6 +80,8 @@ jobs:
           git push origin v${{steps.release.outputs.major}}.${{steps.release.outputs.minor}}.${{steps.release.outputs.patch}} || true
 
       - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
       - name: Install pkger
         run: |
           curl -s -L -o pkger.tgz ${{ needs.test.outputs.pkger }}

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -60,6 +60,8 @@ jobs:
         run: |
           curl -s -L -o pkger.tgz ${{ steps.pkger-download-url.outputs.result }}
           tar xvzf pkger.tgz
+      - name: Clear Cache
+        run: go clean -modcache -testcache -cache
       - name: Unit Test
         run: make test
         env:

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
       - name: Determine platform binaries
         id: pkger-binaries
         uses: actions/github-script@v2
@@ -82,8 +84,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "^1.16"
       - name: Install Podman
         run: |
           . /etc/os-release
@@ -112,8 +115,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Go
-        uses: actions/setup-go@v2
+      - uses: actions/setup-go@v2
         with:
           go-version: "^1.16"
       - name: Determine download URL for latest pkger

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /coverage.out
 /bin
 
-target
+/target
 node_modules
 __pycache__
 /coverage.out

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module knative.dev/kn-plugin-func
 
-go 1.15
+go 1.16
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.14

--- a/go.sum
+++ b/go.sum
@@ -436,7 +436,6 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/evanphx/json-patch/v5 v5.5.0 h1:bAmFiUJ+o0o2B4OiTFeE3MqCOtyo+jjPP9iZ0VRxYUc=
 github.com/evanphx/json-patch/v5 v5.5.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=

--- a/vendor/sigs.k8s.io/kustomize/api/internal/target/errmissingkustomization.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/target/errmissingkustomization.go
@@ -1,0 +1,48 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/kustomize/api/konfig"
+)
+
+type errMissingKustomization struct {
+	path string
+}
+
+func (e *errMissingKustomization) Error() string {
+	return fmt.Sprintf(
+		"unable to find one of %v in directory '%s'",
+		commaOr(quoted(konfig.RecognizedKustomizationFileNames())),
+		e.path)
+}
+
+func IsMissingKustomizationFileError(err error) bool {
+	_, ok := err.(*errMissingKustomization)
+	if ok {
+		return true
+	}
+	_, ok = errors.Cause(err).(*errMissingKustomization)
+	return ok
+}
+
+func NewErrMissingKustomization(p string) *errMissingKustomization {
+	return &errMissingKustomization{path: p}
+}
+
+func quoted(l []string) []string {
+	r := make([]string, len(l))
+	for i, v := range l {
+		r[i] = "'" + v + "'"
+	}
+	return r
+}
+
+func commaOr(q []string) string {
+	return strings.Join(q[:len(q)-1], ", ") + " or " + q[len(q)-1]
+}

--- a/vendor/sigs.k8s.io/kustomize/api/internal/target/kusttarget.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/target/kusttarget.go
@@ -1,0 +1,477 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/kustomize/api/builtins"
+	"sigs.k8s.io/kustomize/api/ifc"
+	"sigs.k8s.io/kustomize/api/internal/accumulator"
+	"sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig"
+	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
+	"sigs.k8s.io/kustomize/api/internal/plugins/loader"
+	"sigs.k8s.io/kustomize/api/internal/utils"
+	"sigs.k8s.io/kustomize/api/konfig"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/resource"
+	"sigs.k8s.io/kustomize/api/types"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+	"sigs.k8s.io/yaml"
+)
+
+// KustTarget encapsulates the entirety of a kustomization build.
+type KustTarget struct {
+	kustomization *types.Kustomization
+	ldr           ifc.Loader
+	validator     ifc.Validator
+	rFactory      *resmap.Factory
+	pLdr          *loader.Loader
+}
+
+// NewKustTarget returns a new instance of KustTarget.
+func NewKustTarget(
+	ldr ifc.Loader,
+	validator ifc.Validator,
+	rFactory *resmap.Factory,
+	pLdr *loader.Loader) *KustTarget {
+	pLdrCopy := *pLdr
+	pLdrCopy.SetWorkDir(ldr.Root())
+	return &KustTarget{
+		ldr:       ldr,
+		validator: validator,
+		rFactory:  rFactory,
+		pLdr:      &pLdrCopy,
+	}
+}
+
+// Load attempts to load the target's kustomization file.
+func (kt *KustTarget) Load() error {
+	content, err := loadKustFile(kt.ldr)
+	if err != nil {
+		return err
+	}
+	content, err = types.FixKustomizationPreUnmarshalling(content)
+	if err != nil {
+		return err
+	}
+	var k types.Kustomization
+	err = k.Unmarshal(content)
+	if err != nil {
+		return err
+	}
+	k.FixKustomizationPostUnmarshalling()
+	errs := k.EnforceFields()
+	if len(errs) > 0 {
+		return fmt.Errorf(
+			"Failed to read kustomization file under %s:\n"+
+				strings.Join(errs, "\n"), kt.ldr.Root())
+	}
+	kt.kustomization = &k
+	return nil
+}
+
+// Kustomization returns a copy of the immutable, internal kustomization object.
+func (kt *KustTarget) Kustomization() types.Kustomization {
+	var result types.Kustomization
+	b, _ := json.Marshal(*kt.kustomization)
+	json.Unmarshal(b, &result)
+	return result
+}
+
+func loadKustFile(ldr ifc.Loader) ([]byte, error) {
+	var content []byte
+	match := 0
+	for _, kf := range konfig.RecognizedKustomizationFileNames() {
+		c, err := ldr.Load(kf)
+		if err == nil {
+			match += 1
+			content = c
+		}
+	}
+	switch match {
+	case 0:
+		return nil, NewErrMissingKustomization(ldr.Root())
+	case 1:
+		return content, nil
+	default:
+		return nil, fmt.Errorf(
+			"Found multiple kustomization files under: %s\n", ldr.Root())
+	}
+}
+
+// MakeCustomizedResMap creates a fully customized ResMap
+// per the instructions contained in its kustomization instance.
+func (kt *KustTarget) MakeCustomizedResMap() (resmap.ResMap, error) {
+	return kt.makeCustomizedResMap()
+}
+
+func (kt *KustTarget) makeCustomizedResMap() (resmap.ResMap, error) {
+	ra, err := kt.AccumulateTarget(&resource.Origin{})
+	if err != nil {
+		return nil, err
+	}
+
+	// The following steps must be done last, not as part of
+	// the recursion implicit in AccumulateTarget.
+
+	err = kt.addHashesToNames(ra)
+	if err != nil {
+		return nil, err
+	}
+
+	// Given that names have changed (prefixs/suffixes added),
+	// fix all the back references to those names.
+	err = ra.FixBackReferences()
+	if err != nil {
+		return nil, err
+	}
+
+	// With all the back references fixed, it's OK to resolve Vars.
+	err = ra.ResolveVars()
+	if err != nil {
+		return nil, err
+	}
+
+	return ra.ResMap(), nil
+}
+
+func (kt *KustTarget) addHashesToNames(
+	ra *accumulator.ResAccumulator) error {
+	p := builtins.NewHashTransformerPlugin()
+	err := kt.configureBuiltinPlugin(p, nil, builtinhelpers.HashTransformer)
+	if err != nil {
+		return err
+	}
+	return ra.Transform(p)
+}
+
+// AccumulateTarget returns a new ResAccumulator,
+// holding customized resources and the data/rules used
+// to do so.  The name back references and vars are
+// not yet fixed.
+// The origin parameter is used through the recursive calls
+// to annotate each resource with information about where
+// the resource came from, e.g. the file and/or the repository
+// it originated from.
+// As an entrypoint, one can pass an empty resource.Origin object to
+// AccumulateTarget. As AccumulateTarget moves recursively
+// through kustomization directories, it updates `origin.path`
+// accordingly. When a remote base is found, it updates `origin.repo`
+// and `origin.ref` accordingly.
+func (kt *KustTarget) AccumulateTarget(origin *resource.Origin) (
+	ra *accumulator.ResAccumulator, err error) {
+	return kt.accumulateTarget(accumulator.MakeEmptyAccumulator(), origin)
+}
+
+// ra should be empty when this KustTarget is a Kustomization, or the ra of the parent if this KustTarget is a Component
+// (or empty if the Component does not have a parent).
+func (kt *KustTarget) accumulateTarget(ra *accumulator.ResAccumulator, origin *resource.Origin) (
+	resRa *accumulator.ResAccumulator, err error) {
+	ra, err = kt.accumulateResources(ra, kt.kustomization.Resources, origin)
+	if err != nil {
+		return nil, errors.Wrap(err, "accumulating resources")
+	}
+	ra, err = kt.accumulateComponents(ra, kt.kustomization.Components, origin)
+	if err != nil {
+		return nil, errors.Wrap(err, "accumulating components")
+	}
+	tConfig, err := builtinconfig.MakeTransformerConfig(
+		kt.ldr, kt.kustomization.Configurations)
+	if err != nil {
+		return nil, err
+	}
+	err = ra.MergeConfig(tConfig)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "merging config %v", tConfig)
+	}
+	crdTc, err := accumulator.LoadConfigFromCRDs(kt.ldr, kt.kustomization.Crds)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "loading CRDs %v", kt.kustomization.Crds)
+	}
+	err = ra.MergeConfig(crdTc)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "merging CRDs %v", crdTc)
+	}
+	err = kt.runGenerators(ra)
+	if err != nil {
+		return nil, err
+	}
+	err = kt.runTransformers(ra)
+	if err != nil {
+		return nil, err
+	}
+	err = kt.runValidators(ra)
+	if err != nil {
+		return nil, err
+	}
+	err = ra.MergeVars(kt.kustomization.Vars)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "merging vars %v", kt.kustomization.Vars)
+	}
+	return ra, nil
+}
+
+func (kt *KustTarget) runGenerators(
+	ra *accumulator.ResAccumulator) error {
+	var generators []resmap.Generator
+	gs, err := kt.configureBuiltinGenerators()
+	if err != nil {
+		return err
+	}
+	generators = append(generators, gs...)
+	gs, err = kt.configureExternalGenerators()
+	if err != nil {
+		return errors.Wrap(err, "loading generator plugins")
+	}
+	generators = append(generators, gs...)
+	for _, g := range generators {
+		resMap, err := g.Generate()
+		if err != nil {
+			return err
+		}
+		err = ra.AbsorbAll(resMap)
+		if err != nil {
+			return errors.Wrapf(err, "merging from generator %v", g)
+		}
+	}
+	return nil
+}
+
+func (kt *KustTarget) configureExternalGenerators() ([]resmap.Generator, error) {
+	ra := accumulator.MakeEmptyAccumulator()
+	var generatorPaths []string
+	for _, p := range kt.kustomization.Generators {
+		// handle inline generators
+		rm, err := kt.rFactory.NewResMapFromBytes([]byte(p))
+		if err != nil {
+			// not an inline config
+			generatorPaths = append(generatorPaths, p)
+			continue
+		}
+		ra.AppendAll(rm)
+	}
+	ra, err := kt.accumulateResources(ra, generatorPaths, &resource.Origin{})
+	if err != nil {
+		return nil, err
+	}
+	return kt.pLdr.LoadGenerators(kt.ldr, kt.validator, ra.ResMap())
+}
+
+func (kt *KustTarget) runTransformers(ra *accumulator.ResAccumulator) error {
+	var r []resmap.Transformer
+	tConfig := ra.GetTransformerConfig()
+	lts, err := kt.configureBuiltinTransformers(tConfig)
+	if err != nil {
+		return err
+	}
+	r = append(r, lts...)
+	lts, err = kt.configureExternalTransformers(kt.kustomization.Transformers)
+	if err != nil {
+		return err
+	}
+	r = append(r, lts...)
+	return ra.Transform(newMultiTransformer(r))
+}
+
+func (kt *KustTarget) configureExternalTransformers(transformers []string) ([]resmap.Transformer, error) {
+	ra := accumulator.MakeEmptyAccumulator()
+	var transformerPaths []string
+	for _, p := range transformers {
+		// handle inline transformers
+		rm, err := kt.rFactory.NewResMapFromBytes([]byte(p))
+		if err != nil {
+			// not an inline config
+			transformerPaths = append(transformerPaths, p)
+			continue
+		}
+		ra.AppendAll(rm)
+	}
+	ra, err := kt.accumulateResources(ra, transformerPaths, &resource.Origin{})
+	if err != nil {
+		return nil, err
+	}
+	return kt.pLdr.LoadTransformers(kt.ldr, kt.validator, ra.ResMap())
+}
+
+func (kt *KustTarget) runValidators(ra *accumulator.ResAccumulator) error {
+	validators, err := kt.configureExternalTransformers(kt.kustomization.Validators)
+	if err != nil {
+		return err
+	}
+	for _, v := range validators {
+		// Validators shouldn't modify the resource map
+		orignal := ra.ResMap().DeepCopy()
+		err = v.Transform(ra.ResMap())
+		if err != nil {
+			return err
+		}
+		newMap := ra.ResMap().DeepCopy()
+		if err = kt.removeValidatedByLabel(newMap); err != nil {
+			return err
+		}
+		if err = orignal.ErrorIfNotEqualSets(newMap); err != nil {
+			return fmt.Errorf("validator shouldn't modify the resource map: %v", err)
+		}
+	}
+	return nil
+}
+
+func (kt *KustTarget) removeValidatedByLabel(rm resmap.ResMap) error {
+	resources := rm.Resources()
+	for _, r := range resources {
+		labels := r.GetLabels()
+		if _, found := labels[konfig.ValidatedByLabelKey]; !found {
+			continue
+		}
+		delete(labels, konfig.ValidatedByLabelKey)
+		if err := r.SetLabels(labels); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// accumulateResources fills the given resourceAccumulator
+// with resources read from the given list of paths.
+func (kt *KustTarget) accumulateResources(
+	ra *accumulator.ResAccumulator, paths []string, origin *resource.Origin) (*accumulator.ResAccumulator, error) {
+	for _, path := range paths {
+		// try loading resource as file then as base (directory or git repository)
+		if errF := kt.accumulateFile(ra, path, origin); errF != nil {
+			ldr, err := kt.ldr.New(path)
+			if err != nil {
+				return nil, errors.Wrapf(
+					err, "accumulation err='%s'", errF.Error())
+			}
+			ra, err = kt.accumulateDirectory(ra, ldr, origin.Append(path), false)
+			if err != nil {
+				return nil, errors.Wrapf(
+					err, "accumulation err='%s'", errF.Error())
+			}
+		}
+	}
+	return ra, nil
+}
+
+// accumulateResources fills the given resourceAccumulator
+// with resources read from the given list of paths.
+func (kt *KustTarget) accumulateComponents(
+	ra *accumulator.ResAccumulator, paths []string, origin *resource.Origin) (*accumulator.ResAccumulator, error) {
+	for _, path := range paths {
+		// Components always refer to directories
+		ldr, errL := kt.ldr.New(path)
+		if errL != nil {
+			return nil, fmt.Errorf("loader.New %q", errL)
+		}
+		var errD error
+		origin.Path = filepath.Join(origin.Path, path)
+		ra, errD = kt.accumulateDirectory(ra, ldr, origin, true)
+		if errD != nil {
+			return nil, fmt.Errorf("accumulateDirectory: %q", errD)
+		}
+	}
+	return ra, nil
+}
+
+func (kt *KustTarget) accumulateDirectory(
+	ra *accumulator.ResAccumulator, ldr ifc.Loader, origin *resource.Origin, isComponent bool) (*accumulator.ResAccumulator, error) {
+	defer ldr.Cleanup()
+	subKt := NewKustTarget(ldr, kt.validator, kt.rFactory, kt.pLdr)
+	err := subKt.Load()
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "couldn't make target for path '%s'", ldr.Root())
+	}
+	subKt.kustomization.BuildMetadata = kt.kustomization.BuildMetadata
+	var bytes []byte
+	path := ldr.Root()
+	if openApiPath, exists := subKt.Kustomization().OpenAPI["path"]; exists {
+		bytes, err = ldr.Load(filepath.Join(path, openApiPath))
+		if err != nil {
+			return nil, err
+		}
+	}
+	err = openapi.SetSchema(subKt.Kustomization().OpenAPI, bytes, false)
+	if err != nil {
+		return nil, err
+	}
+	if isComponent && subKt.kustomization.Kind != types.ComponentKind {
+		return nil, fmt.Errorf(
+			"expected kind '%s' for path '%s' but got '%s'", types.ComponentKind, ldr.Root(), subKt.kustomization.Kind)
+	} else if !isComponent && subKt.kustomization.Kind == types.ComponentKind {
+		return nil, fmt.Errorf(
+			"expected kind != '%s' for path '%s'", types.ComponentKind, ldr.Root())
+	}
+
+	var subRa *accumulator.ResAccumulator
+	if isComponent {
+		// Components don't create a new accumulator: the kustomization directives are added to the current accumulator
+		subRa, err = subKt.accumulateTarget(ra, origin)
+		ra = accumulator.MakeEmptyAccumulator()
+	} else {
+		// Child Kustomizations create a new accumulator which resolves their kustomization directives, which will later
+		// be merged into the current accumulator.
+		subRa, err = subKt.AccumulateTarget(origin)
+	}
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "recursed accumulation of path '%s'", ldr.Root())
+	}
+	err = ra.MergeAccumulator(subRa)
+	if err != nil {
+		return nil, errors.Wrapf(
+			err, "recursed merging from path '%s'", ldr.Root())
+	}
+	return ra, nil
+}
+
+func (kt *KustTarget) accumulateFile(
+	ra *accumulator.ResAccumulator, path string, origin *resource.Origin) error {
+	resources, err := kt.rFactory.FromFile(kt.ldr, path)
+	if err != nil {
+		return errors.Wrapf(err, "accumulating resources from '%s'", path)
+	}
+	if utils.StringSliceContains(kt.kustomization.BuildMetadata, "originAnnotations") {
+		origin = origin.Append(path)
+		err = resources.AnnotateAll(utils.OriginAnnotation, origin.String())
+		if err != nil {
+			return errors.Wrapf(err, "cannot add path annotation for '%s'", path)
+		}
+	}
+	err = ra.AppendAll(resources)
+	if err != nil {
+		return errors.Wrapf(err, "merging resources from '%s'", path)
+	}
+	return nil
+}
+
+func (kt *KustTarget) configureBuiltinPlugin(
+	p resmap.Configurable, c interface{}, bpt builtinhelpers.BuiltinPluginType) (err error) {
+	var y []byte
+	if c != nil {
+		y, err = yaml.Marshal(c)
+		if err != nil {
+			return errors.Wrapf(
+				err, "builtin %s marshal", bpt)
+		}
+	}
+	err = p.Config(
+		resmap.NewPluginHelpers(
+			kt.ldr, kt.validator, kt.rFactory, kt.pLdr.Config()),
+		y)
+	if err != nil {
+		return errors.Wrapf(
+			err, "trouble configuring builtin %s with config: `\n%s`", bpt, string(y))
+	}
+	return nil
+}

--- a/vendor/sigs.k8s.io/kustomize/api/internal/target/kusttarget_configplugin.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/target/kusttarget_configplugin.go
@@ -1,0 +1,367 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/kustomize/api/internal/plugins/builtinconfig"
+	"sigs.k8s.io/kustomize/api/internal/plugins/builtinhelpers"
+	"sigs.k8s.io/kustomize/api/resmap"
+	"sigs.k8s.io/kustomize/api/types"
+)
+
+// Functions dedicated to configuring the builtin
+// transformer and generator plugins using config data
+// read from a kustomization file and from the
+// config.TransformerConfig, whose data may be a
+// mix of hardcoded values and data read from file.
+//
+// Non-builtin plugins will get their configuration
+// from their own dedicated structs and YAML files.
+//
+// There are some loops in the functions below because
+// the kustomization file would, say, allow someone to
+// request multiple secrets be made, or run multiple
+// image tag transforms.  In these cases, we'll need
+// N plugin instances with differing configurations.
+
+func (kt *KustTarget) configureBuiltinGenerators() (
+	result []resmap.Generator, err error) {
+	for _, bpt := range []builtinhelpers.BuiltinPluginType{
+		builtinhelpers.ConfigMapGenerator,
+		builtinhelpers.SecretGenerator,
+		builtinhelpers.HelmChartInflationGenerator,
+	} {
+		r, err := generatorConfigurators[bpt](
+			kt, bpt, builtinhelpers.GeneratorFactories[bpt])
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, r...)
+	}
+	return result, nil
+}
+
+func (kt *KustTarget) configureBuiltinTransformers(
+	tc *builtinconfig.TransformerConfig) (
+	result []resmap.Transformer, err error) {
+	for _, bpt := range []builtinhelpers.BuiltinPluginType{
+		builtinhelpers.PatchStrategicMergeTransformer,
+		builtinhelpers.PatchTransformer,
+		builtinhelpers.NamespaceTransformer,
+		builtinhelpers.PrefixSuffixTransformer,
+		builtinhelpers.LabelTransformer,
+		builtinhelpers.AnnotationsTransformer,
+		builtinhelpers.PatchJson6902Transformer,
+		builtinhelpers.ReplicaCountTransformer,
+		builtinhelpers.ImageTagTransformer,
+		builtinhelpers.ReplacementTransformer,
+	} {
+		r, err := transformerConfigurators[bpt](
+			kt, bpt, builtinhelpers.TransformerFactories[bpt], tc)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, r...)
+	}
+	return result, nil
+}
+
+type gFactory func() resmap.GeneratorPlugin
+
+var generatorConfigurators = map[builtinhelpers.BuiltinPluginType]func(
+	kt *KustTarget,
+	bpt builtinhelpers.BuiltinPluginType,
+	factory gFactory) (result []resmap.Generator, err error){
+	builtinhelpers.SecretGenerator: func(kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f gFactory) (
+		result []resmap.Generator, err error) {
+		var c struct {
+			types.SecretArgs
+		}
+		for _, args := range kt.kustomization.SecretGenerator {
+			c.SecretArgs = args
+			c.SecretArgs.Options = types.MergeGlobalOptionsIntoLocal(
+				c.SecretArgs.Options, kt.kustomization.GeneratorOptions)
+			p := f()
+			err := kt.configureBuiltinPlugin(p, c, bpt)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		return
+	},
+
+	builtinhelpers.ConfigMapGenerator: func(kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f gFactory) (
+		result []resmap.Generator, err error) {
+		var c struct {
+			types.ConfigMapArgs
+		}
+		for _, args := range kt.kustomization.ConfigMapGenerator {
+			c.ConfigMapArgs = args
+			c.ConfigMapArgs.Options = types.MergeGlobalOptionsIntoLocal(
+				c.ConfigMapArgs.Options, kt.kustomization.GeneratorOptions)
+			p := f()
+			err := kt.configureBuiltinPlugin(p, c, bpt)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		return
+	},
+
+	builtinhelpers.HelmChartInflationGenerator: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f gFactory) (
+		result []resmap.Generator, err error) {
+		var c struct {
+			types.HelmGlobals
+			types.HelmChart
+		}
+		var globals types.HelmGlobals
+		if kt.kustomization.HelmGlobals != nil {
+			globals = *kt.kustomization.HelmGlobals
+		}
+		for _, chart := range kt.kustomization.HelmCharts {
+			c.HelmGlobals = globals
+			c.HelmChart = chart
+			p := f()
+			if err = kt.configureBuiltinPlugin(p, c, bpt); err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		return
+	},
+}
+
+type tFactory func() resmap.TransformerPlugin
+
+var transformerConfigurators = map[builtinhelpers.BuiltinPluginType]func(
+	kt *KustTarget,
+	bpt builtinhelpers.BuiltinPluginType,
+	f tFactory,
+	tc *builtinconfig.TransformerConfig) (result []resmap.Transformer, err error){
+	builtinhelpers.NamespaceTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, tc *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		var c struct {
+			types.ObjectMeta `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+			FieldSpecs       []types.FieldSpec
+		}
+		c.Namespace = kt.kustomization.Namespace
+		c.FieldSpecs = tc.NameSpace
+		p := f()
+		err = kt.configureBuiltinPlugin(p, c, bpt)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+		return
+	},
+
+	builtinhelpers.PatchJson6902Transformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, _ *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		var c struct {
+			Target *types.Selector `json:"target,omitempty" yaml:"target,omitempty"`
+			Path   string          `json:"path,omitempty" yaml:"path,omitempty"`
+			JsonOp string          `json:"jsonOp,omitempty" yaml:"jsonOp,omitempty"`
+		}
+		for _, args := range kt.kustomization.PatchesJson6902 {
+			c.Target = args.Target
+			c.Path = args.Path
+			c.JsonOp = args.Patch
+			p := f()
+			err = kt.configureBuiltinPlugin(p, c, bpt)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		return
+	},
+	builtinhelpers.PatchStrategicMergeTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, _ *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		if len(kt.kustomization.PatchesStrategicMerge) == 0 {
+			return
+		}
+		var c struct {
+			Paths []types.PatchStrategicMerge `json:"paths,omitempty" yaml:"paths,omitempty"`
+		}
+		c.Paths = kt.kustomization.PatchesStrategicMerge
+		p := f()
+		err = kt.configureBuiltinPlugin(p, c, bpt)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+		return
+	},
+	builtinhelpers.PatchTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, _ *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		if len(kt.kustomization.Patches) == 0 {
+			return
+		}
+		var c struct {
+			Path    string          `json:"path,omitempty" yaml:"path,omitempty"`
+			Patch   string          `json:"patch,omitempty" yaml:"patch,omitempty"`
+			Target  *types.Selector `json:"target,omitempty" yaml:"target,omitempty"`
+			Options map[string]bool `json:"options,omitempty" yaml:"options,omitempty"`
+		}
+		for _, pc := range kt.kustomization.Patches {
+			c.Target = pc.Target
+			c.Patch = pc.Patch
+			c.Path = pc.Path
+			c.Options = pc.Options
+			p := f()
+			err = kt.configureBuiltinPlugin(p, c, bpt)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		return
+	},
+	builtinhelpers.LabelTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, tc *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		for _, label := range kt.kustomization.Labels {
+			var c struct {
+				Labels     map[string]string
+				FieldSpecs []types.FieldSpec
+			}
+			c.Labels = label.Pairs
+			fss := types.FsSlice(label.FieldSpecs)
+			// merge the custom fieldSpecs with the default
+			if label.IncludeSelectors {
+				fss, err = fss.MergeAll(tc.CommonLabels)
+			} else {
+				// only add to metadata by default
+				fss, err = fss.MergeOne(types.FieldSpec{Path: "metadata/labels", CreateIfNotPresent: true})
+			}
+			if err != nil {
+				return nil, err
+			}
+			c.FieldSpecs = fss
+			p := f()
+			err = kt.configureBuiltinPlugin(p, c, bpt)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		var c struct {
+			Labels     map[string]string
+			FieldSpecs []types.FieldSpec
+		}
+		c.Labels = kt.kustomization.CommonLabels
+		c.FieldSpecs = tc.CommonLabels
+		p := f()
+		err = kt.configureBuiltinPlugin(p, c, bpt)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+		return
+	},
+	builtinhelpers.AnnotationsTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, tc *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		var c struct {
+			Annotations map[string]string
+			FieldSpecs  []types.FieldSpec
+		}
+		c.Annotations = kt.kustomization.CommonAnnotations
+		c.FieldSpecs = tc.CommonAnnotations
+		p := f()
+		err = kt.configureBuiltinPlugin(p, c, bpt)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+		return
+	},
+	builtinhelpers.PrefixSuffixTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, tc *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		var c struct {
+			Prefix     string
+			Suffix     string
+			FieldSpecs []types.FieldSpec
+		}
+		c.Prefix = kt.kustomization.NamePrefix
+		c.Suffix = kt.kustomization.NameSuffix
+		c.FieldSpecs = tc.NamePrefix
+		p := f()
+		err = kt.configureBuiltinPlugin(p, c, bpt)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+		return
+	},
+	builtinhelpers.ImageTagTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, tc *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		var c struct {
+			ImageTag   types.Image
+			FieldSpecs []types.FieldSpec
+		}
+		for _, args := range kt.kustomization.Images {
+			c.ImageTag = args
+			c.FieldSpecs = tc.Images
+			p := f()
+			err = kt.configureBuiltinPlugin(p, c, bpt)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		return
+	},
+	builtinhelpers.ReplacementTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, _ *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		var c struct {
+			Replacements []types.ReplacementField
+		}
+		c.Replacements = kt.kustomization.Replacements
+		p := f()
+		err = kt.configureBuiltinPlugin(p, c, bpt)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, p)
+		return result, nil
+	},
+	builtinhelpers.ReplicaCountTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, tc *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		var c struct {
+			Replica    types.Replica
+			FieldSpecs []types.FieldSpec
+		}
+		for _, args := range kt.kustomization.Replicas {
+			c.Replica = args
+			c.FieldSpecs = tc.Replicas
+			p := f()
+			err = kt.configureBuiltinPlugin(p, c, bpt)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, p)
+		}
+		return
+	},
+	// No kustomization file keyword for this yet.
+	builtinhelpers.ValueAddTransformer: func(
+		kt *KustTarget, bpt builtinhelpers.BuiltinPluginType, f tFactory, tc *builtinconfig.TransformerConfig) (
+		result []resmap.Transformer, err error) {
+		return nil, fmt.Errorf("valueadd keyword not yet defined")
+	},
+}

--- a/vendor/sigs.k8s.io/kustomize/api/internal/target/multitransformer.go
+++ b/vendor/sigs.k8s.io/kustomize/api/internal/target/multitransformer.go
@@ -1,0 +1,36 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package target
+
+import (
+	"sigs.k8s.io/kustomize/api/resmap"
+)
+
+// multiTransformer contains a list of transformers.
+type multiTransformer struct {
+	transformers []resmap.Transformer
+}
+
+var _ resmap.Transformer = &multiTransformer{}
+
+// newMultiTransformer constructs a multiTransformer.
+func newMultiTransformer(t []resmap.Transformer) resmap.Transformer {
+	r := &multiTransformer{
+		transformers: make([]resmap.Transformer, len(t)),
+	}
+	copy(r.transformers, t)
+	return r
+}
+
+// Transform applies the member transformers in order to the resources,
+// optionally detecting and erroring on commutation conflict.
+func (o *multiTransformer) Transform(m resmap.ResMap) error {
+	for _, t := range o.transformers {
+		if err := t.Transform(m); err != nil {
+			return err
+		}
+		m.DropEmpties()
+	}
+	return nil
+}


### PR DESCRIPTION
This PR bumps the version of go to 1.16 to alleviate a build issue durring vendoring which appeard to fail to find a method in the stdlib which was introduced recently. A subsequent `tidy` also ended up making a small removal.